### PR TITLE
sdk tests always require micronaut security

### DIFF
--- a/lib/src/main/resources/Micronaut/project/build.gradle.kts.mustache
+++ b/lib/src/main/resources/Micronaut/project/build.gradle.kts.mustache
@@ -18,6 +18,7 @@ dependencies {
     api("io.micronaut:micronaut-http-client")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.1")
+    testImplementation("io.micronaut.security:micronaut-security-jwt")
 }
 
 java {


### PR DESCRIPTION
le `fromOperation` génère toujours deux fichiers qui dépendent de micronaut-security


```
                var hasSecurityJwt = (boolean) operation.vendorExtensions.getOrDefault("has401", false);
		if (generateApiTests && hasSecurityJwt) {
			addSupportingFile(testFolder, invokerPackage, "JwtProvider");
			addSupportingFile(testFolder, invokerPackage, "JwtBuilder");
		}
```

On aurait voulu se baser sur le flag qui active l'authentification, mais l'opération est créé dans la méthode `fromAction` de base

@Chris-V  Si tu as une meilleur idée de fix tu pourra y revenir.